### PR TITLE
Remove fusion reactor log spam

### DIFF
--- a/Source/FarFutureTechnologies/Modules/FusionReactor.cs
+++ b/Source/FarFutureTechnologies/Modules/FusionReactor.cs
@@ -486,7 +486,7 @@ namespace FarFutureTechnologies
           modes[currentModeIndex].powerGeneration * TimeWarp.fixedDeltaTime);
 
 
-        Debug.Log($"L1: {requestedFramePower}, {shipEC}, {shipMaxEC} {clampedFramePower}");
+        //Debug.Log($"L1: {requestedFramePower}, {shipEC}, {shipMaxEC} {clampedFramePower}");
 
 
 
@@ -497,7 +497,7 @@ namespace FarFutureTechnologies
         powerGenerated = modes[currentModeIndex].powerGeneration * reactorThrottle;
         fuelConsumption = 0d;
 
-        Debug.Log($"L2: {reactorThrottle}, {powerGenerated}, {modes[currentModeIndex].powerGeneration}, {TimeWarp.fixedDeltaTime}");
+        //Debug.Log($"L2: {reactorThrottle}, {powerGenerated}, {modes[currentModeIndex].powerGeneration}, {TimeWarp.fixedDeltaTime}");
 
         bool fuelCheckPassed = true;
         for (int i = 0; i < modes[currentModeIndex].inputs.Count; i++)


### PR DESCRIPTION
These were getting sent to the log every fixedupdate, not good! (it's a miracle I found the source mod of this, github search is amazing)

<img width="1345" height="781" alt="image" src="https://github.com/user-attachments/assets/5a18c3cf-96af-4384-a951-b80eb0171b12" />
