### PR TITLE
Fix fft-atmosphere-scoop-1.cfg to match description. Shock and Circular intakes were flipped.

### DIFF
--- a/GameData/FarFutureTechnologies/Parts/Resources/fft-atmosphere-scoop-1.cfg
+++ b/GameData/FarFutureTechnologies/Parts/Resources/fft-atmosphere-scoop-1.cfg
@@ -138,7 +138,7 @@ PART
         }
         DATA
         {
-          IntakeArea = 4
+          IntakeArea = 2 
           IntakeVelocityScale
           {
             key = 0 .1
@@ -197,7 +197,7 @@ PART
         }
         DATA
         {
-          IntakeArea = 2
+          IntakeArea = 4
           IntakeVelocityScale
           {
             key = 0 1


### PR DESCRIPTION
Intake Description says its 4.0m^2.

Arguably, this should be higher since it requires subsonic, and is heavier and costlier than the shock cone. Tested on Duna at 140m/s - and both intakes would take over 20 circumnavigations to fill a small 2.5m tank.... and there isn't another viable Argon Harvesting Candidate in the entirely solar system.

Personally, I'm going to be using a module manager patch to bump it to 16. (Since the area of a circle with radius 2.25 is 15.9. Yes, It's "OP" - sorry, I'm not spending 100 hours flying a plane at 200m above terrain on duna, and I hope that's understandable)

Edit: Remaking this since I accidentally deleted my copy of the repo. 